### PR TITLE
Add sample MCP client and server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
-"# sampleMCP" 
+# sampleMCP
+
+このリポジトリは、Model Context Protocol (MCP) の非常にシンプルなクライアントとサーバーのサンプル実装です。JSON Lines 形式を使った TCP 通信上でハンドシェイク・ツール一覧・ツール実行という基本的なフローを確認できます。
+
+## 構成
+
+```
+.
+├── mcp_sample/
+│   ├── __init__.py
+│   ├── client.py
+│   ├── protocol.py
+│   └── server.py
+└── tests/
+    └── test_integration.py
+```
+
+- `mcp_sample.server` は 2 つのツール (`echo` と `uppercase`) を公開する MCP サーバーです。
+- `mcp_sample.client` はサーバーとハンドシェイクを行い、`list_tools` / `call_tool` リクエストを送信するクライアントです。
+- `tests/test_integration.py` ではサーバーとクライアントの往復通信を確認します。
+
+## 使い方
+
+### サーバーの起動
+
+```
+python -m mcp_sample.server
+```
+
+デフォルトでは `127.0.0.1:8765` で待ち受けます。ログに接続状況が表示されます。
+
+### クライアントの実行
+
+別のターミナルで次を実行し、サーバーに接続します。
+
+```
+python -m mcp_sample.client --message "こんにちは"
+```
+
+サーバーからのレスポンスが JSON 形式で出力されます。
+
+### テスト
+
+```
+pytest
+```
+
+サーバーとクライアントが正しく通信できることを確認します。

--- a/mcp_sample/__init__.py
+++ b/mcp_sample/__init__.py
@@ -1,0 +1,3 @@
+"""Sample implementation of a minimal MCP client and server."""
+
+PROTOCOL_VERSION = "1.0"

--- a/mcp_sample/client.py
+++ b/mcp_sample/client.py
@@ -1,0 +1,81 @@
+"""Minimal MCP client implementation for demonstration purposes."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from typing import Any, Dict
+
+from .protocol import build_handshake, decode_message, encode_message, is_handshake
+
+
+async def read_message(reader: asyncio.StreamReader) -> Dict[str, Any]:
+    raw = await reader.readline()
+    if not raw:
+        raise ConnectionError("Connection closed by server")
+    return decode_message(raw)
+
+
+async def run_client(host: str = "127.0.0.1", port: int = 8765, *, message: str = "Hello, MCP!") -> Dict[str, Any]:
+    reader, writer = await asyncio.open_connection(host, port)
+
+    writer.write(encode_message(build_handshake("client")))
+    await writer.drain()
+    response = await read_message(reader)
+    if not is_handshake(response):
+        raise RuntimeError(f"Invalid handshake response: {json.dumps(response)}")
+
+    writer.write(encode_message({
+        "type": "request",
+        "id": 1,
+        "method": "list_tools",
+    }))
+    await writer.drain()
+    tools_response = await read_message(reader)
+
+    writer.write(encode_message({
+        "type": "request",
+        "id": 2,
+        "method": "call_tool",
+        "params": {"name": "echo", "arguments": {"message": message}},
+    }))
+    await writer.drain()
+    echo_response = await read_message(reader)
+
+    writer.write(encode_message({
+        "type": "request",
+        "id": 3,
+        "method": "call_tool",
+        "params": {"name": "uppercase", "arguments": {"message": message}},
+    }))
+    await writer.drain()
+    upper_response = await read_message(reader)
+
+    writer.close()
+    await writer.wait_closed()
+
+    return {
+        "tools": tools_response,
+        "echo": echo_response,
+        "uppercase": upper_response,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the sample MCP client")
+    parser.add_argument("--host", default="127.0.0.1", help="Hostname of the MCP server")
+    parser.add_argument("--port", type=int, default=8765, help="Port of the MCP server")
+    parser.add_argument(
+        "--message",
+        default="Hello, MCP!",
+        help="Message to send to the echo and uppercase tools",
+    )
+    args = parser.parse_args()
+
+    responses = asyncio.run(run_client(args.host, args.port, message=args.message))
+    print(json.dumps(responses, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp_sample/protocol.py
+++ b/mcp_sample/protocol.py
@@ -1,0 +1,31 @@
+"""Utility helpers for the sample MCP implementation."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+from . import PROTOCOL_VERSION
+
+
+def encode_message(message: Dict[str, Any]) -> bytes:
+    """Serialize a message to a JSON line for transport."""
+    return (json.dumps(message, separators=(",", ":")) + "\n").encode("utf-8")
+
+
+def decode_message(raw: bytes) -> Dict[str, Any]:
+    """Deserialize a message from a JSON line."""
+    return json.loads(raw.decode("utf-8"))
+
+
+def build_handshake(role: str) -> Dict[str, Any]:
+    """Create a handshake payload for the given role."""
+    return {"type": "handshake", "protocol": PROTOCOL_VERSION, "role": role}
+
+
+def is_handshake(message: Dict[str, Any]) -> bool:
+    """Return True when the message represents a MCP handshake."""
+    return (
+        message.get("type") == "handshake"
+        and message.get("protocol") == PROTOCOL_VERSION
+    )

--- a/mcp_sample/server.py
+++ b/mcp_sample/server.py
@@ -1,0 +1,150 @@
+"""Minimal MCP server implementation for demonstration purposes."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Dict, Callable
+
+from .protocol import build_handshake, decode_message, encode_message, is_handshake
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ToolRegistry:
+    """Simple in-memory collection of callable tools."""
+
+    def __init__(self) -> None:
+        self._tools: Dict[str, Callable[[Dict[str, Any]], Dict[str, Any]]] = {}
+
+    def register(self, name: str, handler: Callable[[Dict[str, Any]], Dict[str, Any]]) -> None:
+        self._tools[name] = handler
+
+    def describe(self) -> Dict[str, Any]:
+        return {
+            "tools": [
+                {"name": name, "description": handler.__doc__ or ""}
+                for name, handler in sorted(self._tools.items())
+            ]
+        }
+
+    def call(self, name: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        if name not in self._tools:
+            raise ValueError(f"Unknown tool: {name}")
+        return self._tools[name](params)
+
+
+def build_default_registry() -> ToolRegistry:
+    registry = ToolRegistry()
+
+    def echo_tool(params: Dict[str, Any]) -> Dict[str, Any]:
+        """Echo the provided message back to the caller."""
+
+        return {"output": params.get("message", "")}
+
+    def uppercase_tool(params: Dict[str, Any]) -> Dict[str, Any]:
+        """Convert the provided message to uppercase."""
+
+        message = params.get("message", "")
+        return {"output": str(message).upper()}
+
+    registry.register("echo", echo_tool)
+    registry.register("uppercase", uppercase_tool)
+    return registry
+
+
+async def handle_client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter, registry: ToolRegistry) -> None:
+    peer = writer.get_extra_info("peername")
+    LOGGER.info("Client connected: %s", peer)
+    try:
+        raw = await reader.readline()
+        if not raw:
+            LOGGER.warning("Connection closed before handshake from %s", peer)
+            return
+        message = decode_message(raw)
+        if not is_handshake(message):
+            LOGGER.error("Invalid handshake from %s: %s", peer, message)
+            writer.write(encode_message({
+                "type": "error",
+                "error": {"code": 400, "message": "Handshake required"},
+            }))
+            await writer.drain()
+            return
+        writer.write(encode_message(build_handshake("server")))
+        await writer.drain()
+
+        while not reader.at_eof():
+            raw = await reader.readline()
+            if not raw:
+                break
+            message = decode_message(raw)
+            LOGGER.debug("Received message from %s: %s", peer, message)
+            response = await dispatch(message, registry)
+            if response is None:
+                continue
+            writer.write(encode_message(response))
+            await writer.drain()
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive logging
+        LOGGER.exception("Error handling client %s: %s", peer, exc)
+    finally:
+        LOGGER.info("Client disconnected: %s", peer)
+        writer.close()
+        await writer.wait_closed()
+
+
+async def dispatch(message: Dict[str, Any], registry: ToolRegistry) -> Dict[str, Any] | None:
+    if message.get("type") != "request":
+        return {
+            "type": "error",
+            "error": {"code": 400, "message": "Only request messages are supported"},
+        }
+
+    request_id = message.get("id")
+    method = message.get("method")
+    params = message.get("params") or {}
+
+    try:
+        if method == "list_tools":
+            result = registry.describe()
+        elif method == "call_tool":
+            name = params.get("name")
+            if not name:
+                raise ValueError("Missing tool name")
+            tool_params = params.get("arguments") or {}
+            result = registry.call(name, tool_params)
+        else:
+            raise ValueError(f"Unknown method: {method}")
+    except Exception as exc:
+        return {
+            "type": "error",
+            "id": request_id,
+            "error": {"code": 400, "message": str(exc)},
+        }
+
+    return {"type": "response", "id": request_id, "result": result}
+
+
+async def run_server(host: str = "127.0.0.1", port: int = 8765) -> None:
+    registry = build_default_registry()
+    server = await asyncio.start_server(
+        lambda r, w: handle_client(r, w, registry), host, port
+    )
+    addresses = ", ".join(str(sock.getsockname()) for sock in server.sockets or [])
+    LOGGER.info("Serving on %s", addresses)
+    try:
+        async with server:
+            await server.serve_forever()
+    except asyncio.CancelledError:
+        LOGGER.info("Server shutdown requested")
+        raise
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+    asyncio.run(run_server())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,36 @@
+import asyncio
+import json
+
+from mcp_sample.client import run_client
+from mcp_sample.server import run_server
+
+
+def test_client_server_roundtrip():
+    async def runner():
+        host = "127.0.0.1"
+        port = 8765
+
+        server_task = asyncio.create_task(run_server(host, port))
+        try:
+            await asyncio.sleep(0.1)
+            responses = await run_client(host, port, message="test message")
+        finally:
+            server_task.cancel()
+            try:
+                await server_task
+            except asyncio.CancelledError:
+                pass
+
+        assert responses["tools"]["type"] == "response"
+        tools_payload = responses["tools"]["result"]
+        assert any(tool["name"] == "echo" for tool in tools_payload["tools"])
+
+        echo_payload = responses["echo"]["result"]
+        assert echo_payload["output"] == "test message"
+
+        uppercase_payload = responses["uppercase"]["result"]
+        assert uppercase_payload["output"] == "TEST MESSAGE"
+
+        json.dumps(responses)
+
+    asyncio.run(runner())


### PR DESCRIPTION
## Summary
- add a minimal MCP server exposing echo and uppercase tools
- implement a matching MCP client that performs handshake, lists tools, and calls them
- document usage and add an integration test covering the round trip

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9fd9cf6ec83229f2e5b546c3cae5e